### PR TITLE
ci(surge-preview): use the documentation-site repository action

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,53 +9,31 @@ on:
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
 jobs:
-  # inspired from https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/9
-  check_secrets:
-    runs-on: ubuntu-20.04
-    outputs:
-      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
-    steps:
-      - name: Compute secrets availability
-        id: secret_availability
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN_DOC }}
-        run: |
-          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
-          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
   build_preview:
-    needs: [ check_secrets ]
-    # Only build preview for member of the repository
-    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # surge-preview write PR comments
     env:
       COMPONENT_NAME: test-toolkit
-      # Except if you want to test in progress work that your content depends on, keep it set to master
-      DOC_SITE_BRANCH: master
+      COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
+      COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
+      # Required to pass xref validation
+      BCD_BRANCH: '3.6'
       BONITA_BRANCH: '2022.2'
       CLOUD_BRANCH: 'master'
-      BCD_BRANCH: '3.6'
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BONITA_BRANCH_FOR_CLOUD: '2022.1'
     steps:
-      - name: Get documentation site source code
-        if: github.event.action != 'closed'
-        run: |
-          # Remove existing .git directory
-          rm -rf *
-          git clone --depth 1 --single-branch --branch ${DOC_SITE_BRANCH} https://github.com/bonitasoft/bonitasoft.github.io.git .
-      - name: Compute environment variables
-        run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
-          # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
-          repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
-          echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
-      - name: Publish preview
-        uses: afc163/surge-preview@v1
+      - name: Build and publish PR preview
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
         with:
-          surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: build/site
-          failOnError: true
-          teardown: 'true'
-          build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }},2022.1" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
-            ls -lh build/site
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # '>' Replace newlines with spaces (folded)
+          # '-' No newline at end (strip)
+          build-preview-command: >-
+            ./build-preview.bash --use-multi-repositories
+            --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::process-testing-overview.adoc
+            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
+            --component-with-branches bcd:"${{ env.BCD_BRANCH }}" 
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_FOR_CLOUD }}"
+            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"


### PR DESCRIPTION
  - configure the site preview start_page: the preview redirects to the test-toolkit component by default
  - better management of PR created from fork repositories (provided by the action out of the box)
  - simpler configuration

covers https://github.com/bonitasoft/bonita-documentation-site/issues/270