### PR TITLE
ci: add write permissions for the stale workflow

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -7,8 +7,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # actions/stale adds labels and closes PR
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 10 days.'


### PR DESCRIPTION
We are going to set default permissions to read. So use  explicit write permissions when needed.

Also bump actions/stale from v4 to v6

covers https://github.com/bonitasoft/bonita-documentation-site/issues/443