### PR TITLE
ci: simplify the 'PR preview' workflow

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -18,6 +18,7 @@ jobs:
       BONITA_BRANCH: '2022.2'
       CLOUD_BRANCH: 'master'
       BONITA_BRANCH_FOR_CLOUD: '2022.1'
+      BONITA_BRANCH_2021_1: '2021.1'
     steps:
       - name: Build PR preview
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
@@ -29,5 +30,5 @@ jobs:
             --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::process-testing-overview.adoc
             --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}" 
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_FOR_CLOUD }}"
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_2021_1 }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -2,8 +2,6 @@ name: Build PR preview
 
 on:
   pull_request:
-    # To manage 'surge-preview' action teardown, add default event types + closed event type
-    types: [ opened, synchronize, reopened, closed ]
     paths:
       - 'modules/**'
       - 'antora.yml'
@@ -11,8 +9,6 @@ on:
 jobs:
   build_preview:
     runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: write # surge-preview write PR comments
     env:
       COMPONENT_NAME: test-toolkit
       COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
@@ -23,11 +19,9 @@ jobs:
       CLOUD_BRANCH: 'master'
       BONITA_BRANCH_FOR_CLOUD: '2022.1'
     steps:
-      - name: Build and publish PR preview
-        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
+      - name: Build PR preview
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
-          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -1,0 +1,22 @@
+name: Publish PR preview
+
+on:
+  pull_request:
+    # To manage 'surge-preview' action teardown, add default event types + closed event type
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'modules/ROOT/**'
+      - 'antora.yml'
+      - '.github/workflows/publish-pr-preview.yml'
+jobs:
+  build_preview:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # surge-preview write PR comments
+    steps:
+      - name: Build and publish pr preview
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          component-name: test-toolkit


### PR DESCRIPTION
The publish PR preview only build the current branch and publish the preview. It is simple and focus on the current changes.
Introduce a new "build site" workflow in charge of xref validation. This is the current way of working in all repositories.