### PR TITLE
ci: simplify xref validation

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -11,14 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       COMPONENT_NAME: test-toolkit
-      COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
-      # Required to pass xref validation
-      BCD_BRANCHES: '3.6,4.0'
-      BONITA_BRANCHES: '2022.2,2023.1'
-      CLOUD_BRANCH: 'master'
-      BONITA_BRANCH_FOR_CLOUD: '2022.1'
-      BONITA_BRANCH_2021_1: '2021.1'
     steps:
       - name: Build PR preview
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
@@ -26,9 +19,7 @@ jobs:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash --use-multi-repositories
-            --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::process-testing-overview.adoc
-            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
-            --component-with-branches bcd:"${{ env.BCD_BRANCHES }}" 
-            --component-with-branches bonita:"${{ env.BONITA_BRANCHES }},${{ env.BONITA_BRANCH_FOR_CLOUD }},${{ env.BONITA_BRANCH_2021_1 }}"
-            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
+            ./build-preview.bash
+            --component "${{ env.COMPONENT_NAME }}"
+            --branch "${{ env.COMPONENT_BRANCH_NAME }}"
+       


### PR DESCRIPTION
Use the new Antora Atlas feature. There is no more need to reference all dependent components/versions to validate xrefs.

covers https://github.com/bonitasoft/bonita-documentation-site/issues/583