### PR TITLE
ci: fail validation on asciidoctor warnings

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -22,4 +22,4 @@ jobs:
             ./build-preview.bash
             --component "${{ env.COMPONENT_NAME }}"
             --branch "${{ env.COMPONENT_BRANCH_NAME }}"
-       
+          fail-on-warning: true

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -12,5 +12,5 @@ jobs:
         uses: bonitasoft/actions/packages/pr-diff-checker@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM"]'
+          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM", "link:https", "link:http", "xref:https", "xref:http", "xref:_", "xref:#"]'
           extensionsToCheck: '[".adoc"]'

--- a/modules/ROOT/pages/contract.adoc
+++ b/modules/ROOT/pages/contract.adoc
@@ -79,7 +79,7 @@ ContractBuilder.newContract()
 <1> The first level of contract input, the parent complex contract input which contains all the other contract inputs.
 <2> The second level of contract input, a child complex contract input which contains other contract inputs.
 
-If a contract contains several levels of complex contract inputs with a lot of fields, using the Java builder to create the contract can become tedious. When a contract only contains static values, you may extract the contract in an external JSon file and retrieve them xref:_retrieve_contracts_from_files[from the classpath] to keep the test class concise.
+If a contract contains several levels of complex contract inputs with a lot of fields, using the Java builder to create the contract can become tedious. When a contract only contains static values, you may extract the contract in an external JSon file and retrieve them <<retrieve_contracts_from_files, from the classpath>> to keep the test class concise.
 
 [#retrieve_contracts_from_files]
 == Retrieve contracts from files in the classpath

--- a/modules/ROOT/pages/contract.adoc
+++ b/modules/ROOT/pages/contract.adoc
@@ -7,19 +7,19 @@ There are two ways to create contracts: using the Java builder or from a JSon fi
 [NOTE]
 ====
 Integrations tests are built upon the Bonita Test Toolkit, based on the open source https://github.com/bonitasoft/bonita-java-client[Bonita Java Client]. +
-The Bonita Test Toolkit is only available for Enterprise, Performance, Efficiency, and Teamwork. editions. 
+The Bonita Test Toolkit is only available for Enterprise, Performance, Efficiency, and Teamwork. editions.
 ====
 
 == Create contracts using the Java builder
 
 The Java builder allows you to create contracts by specifying contract inputs one by one. +
 It is a pretty handy way to create small contracts, and it gives the possibility to use dynamic values for contract inputs (the persistence ID of a business object created during the test for example). +
-For large and static contracts it is recommended to store them in dedicated JSon files and to retrieve them xref:_retrieve_contracts_from_files[from the classpath].
+For large and static contracts it is recommended to store them in dedicated JSon files and to retrieve them <<retrieve_contracts_from_files, from the classpath>>.
 
 === Simple contract inputs
 
 Simple contract inputs are inputs of type `Text`, `Integer`, `Double`, `Boolean`, `Date`, `LocalDate`, `LocalDateTime`, `OffsetDateTime` and `FileInputValue`. Those inputs car be multiple or not. +
-Simple contract inputs can be added to the contract being built by using the corresponding Java method from the builder: 
+Simple contract inputs can be added to the contract being built by using the corresponding Java method from the builder:
 
 [source, Java]
 ----
@@ -53,7 +53,7 @@ var contractWithMultipleInputs = ContractBuilder.newContract()
 === Complex contract inputs
 
 A complex contract input has for value a list of contract inputs (simple or complex), It can be seen as a tree. +
-It is built like a simple contract input, but with a dedicated builder for the value: 
+It is built like a simple contract input, but with a dedicated builder for the value:
 
 [source, Java]
 ----
@@ -64,7 +64,7 @@ ContractBuilder.newContract()
     .build();
 ----
 
-To build a contract with several levels of complex contract inputs, chain them in the builder: 
+To build a contract with several levels of complex contract inputs, chain them in the builder:
 
 [source, Java]
 ----
@@ -81,9 +81,10 @@ ContractBuilder.newContract()
 
 If a contract contains several levels of complex contract inputs with a lot of fields, using the Java builder to create the contract can become tedious. When a contract only contains static values, you may extract the contract in an external JSon file and retrieve them xref:_retrieve_contracts_from_files[from the classpath] to keep the test class concise.
 
+[#retrieve_contracts_from_files]
 == Retrieve contracts from files in the classpath
 
-Contracts can be stored in JSon files, and then retrieve at runtime from the classpath resources. This allows you to extract the contract definition and the values in a dedicated file, which is easier to read and maintain, especially for large and complex contracts. 
+Contracts can be stored in JSon files, and then retrieve at runtime from the classpath resources. This allows you to extract the contract definition and the values in a dedicated file, which is easier to read and maintain, especially for large and complex contracts.
 
 A contract JSon file works as a key-value model, the key is the name of the contract input and the value of the contract input:
 
@@ -105,8 +106,8 @@ A contract JSon file works as a key-value model, the key is the name of the cont
 ----
 <1> All dates (`LocalDate`, `LocaDateTime`, `OffsetDateTime` and `Date`) are passed as `String` using the https://en.wikipedia.org/wiki/ISO_8601[ISO_8601] standard format.
 
-Contract JSon files have to be available from the classpath at runtime. + 
-To do so, put them for example in a folder `src/test/resources/contracts/`, and then use them in your tests: 
+Contract JSon files have to be available from the classpath at runtime. +
+To do so, put them for example in a folder `src/test/resources/contracts/`, and then use them in your tests:
 
 [source, Java]
 ----

--- a/modules/ROOT/pages/task.adoc
+++ b/modules/ROOT/pages/task.adoc
@@ -6,7 +6,7 @@ Learn to execute tasks and to validate their states in integration tests using t
 [NOTE]
 ====
 Integrations tests are built upon the Bonita Test Toolkit, based on the open-source https://github.com/bonitasoft/bonita-java-client[Bonita Java Client]. +
-The Bonita Test Toolkit is only available for Enterprise, Performance, Efficiency, and Teamwork. editions. 
+The Bonita Test Toolkit is only available for Enterprise, Performance, Efficiency, and Teamwork. editions.
 ====
 
 == Retrieve tasks
@@ -14,14 +14,14 @@ The Bonita Test Toolkit is only available for Enterprise, Performance, Efficienc
 Any task (user task, service task...) defined on a process can be retrieved through the xref:process.adoc#_tasks[process instance]. +
 Keep in mind that only tasks that *have been executed or are ready* can be retrieved, incoming tasks are not accessible.
 
-A task is returned as an object `Task` or `UserTask` (which extends `Task`). + 
+A task is returned as an object `Task` or `UserTask` (which extends `Task`). +
 It offers the possiblity to retrieve some meta information about the task, its state, and gives access to eventual xref:variable.adoc[variables] and xref:connector.adoc[connectors].
 
 Besides that, a user task provides information about candidates, assignee, due date, and can be assigned and executed.
 
 == Assign and execute user tasks
 
-User tasks can be executed using the corresponding process instances to advance processes: 
+User tasks can be executed using the corresponding process instances to advance processes:
 
 [source, Java]
 ----
@@ -64,7 +64,7 @@ class ProcessIT {
 <4> Assign the task to a user.
 <5> Execute the task with or without a contract. The task must have been already assigned.
 <6> Assign and execute the task with or without a contract. If the task is already assigned to another user, it will be reassigned to the new user before to be executed.
-<7> Wait until the task is completed before continuing. Mor details about task predicates in the dedicated section xref:_task_predicates[bellow].
+<7> Wait until the task is completed before continuing. Mor details about task predicates in the dedicated section <<task_predicates, below>>.
 
 == Multi-instantiated UserTask iterator
 
@@ -102,6 +102,7 @@ void validateUserTaskIterator(BonitaTestToolkit toolkit){
 }
 ----
 
+[#task_predicates]
 == Task and UserTask predicates
 
 In order to make asynchronous assertions on processes (using for example http://www.awaitility.org/[Awaitility]), some convenient predicates come with the Bonita test toolkit. It allows ensuring in a scenario that the system is in the expected state before continuing. +


### PR DESCRIPTION
Also fix some wrong xref (anchor in the same page).

The workflow that checks changes now prohibits certain erroneous forms of xref and link, to prevent new errors from being added.

### Notes

See https://github.com/bonitasoft/bonita-documentation-site/pull/596 for more details