### PR TITLE
fix: always use the "bonitaDocVersion" attribute in bonita xref

### DIFF
--- a/modules/ROOT/pages/business-data.adoc
+++ b/modules/ROOT/pages/business-data.adoc
@@ -37,7 +37,7 @@ class ProcessIT {
 
 == Retrieve the value of a business data from a process instance
 
-A business data is defined at the process level, it represents a business object from the xref:bonita:data:define-and-deploy-the-bdm.adoc[Business Data Model]. +
+A business data is defined at the process level, it represents a business object from the xref:{bonitaDocVersion}@bonita:data:define-and-deploy-the-bdm.adoc[Business Data Model]. +
 
 It can be retrieved at any time during a test from the corresponding xref:process.adoc[process instance], archived or not.
 

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -14,4 +14,4 @@ Once installed, you can start using the `bonita-test-toolkit` dependency from an
 
 The Bonita Test Toolkit is available on xref:{bonitaDocVersion}@bonita:software-extensibility:bonita-repository-access.adoc#bonita-artifact-repository[Bonita Artifact Repository] as a standard Maven dependency.
 
-Read the xref:bonita:setup-dev-environment:configure-maven.adoc#repositories[Add a new Maven repository section] to see how to configure your Maven settings in order to access to Bonita Artifact Repository.
+Read the xref:{bonitaDocVersion}@bonita:setup-dev-environment:configure-maven.adoc#repositories[Add a new Maven repository section] to see how to configure your Maven settings in order to access to Bonita Artifact Repository.


### PR DESCRIPTION
This ensures that the xref targets the right bonita version supported by the test-toolkit version. It doesn't depend on bonita "latest" version.

### Notes

Detected while investigating tools for https://github.com/bonitasoft/bonita-documentation-site/issues/594
Completness of the fix: check https://github.com/search?q=repo%3Abonitasoft%2Fbonita-test-toolkit-doc+%22xref%3Abonita%22&type=code (references exist prior merging this PR)