### PR TITLE
feat: add PR Compress Images workflow for image handling

### DIFF
--- a/.github/workflows/pr-compress-images.yml
+++ b/.github/workflows/pr-compress-images.yml
@@ -1,0 +1,21 @@
+name: PR Compress Images
+on:
+  pull_request_target:
+    # Run Image Actions when JPG, JPEG, PNG or WebP files are added or changed
+    paths:
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.png'
+      - '**.webp'
+      - '.github/workflows/pr-compress-images.yml'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  compress_images:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: bonitasoft/bonita-documentation-site/.github/workflows/_reusable_compress-images.yml@master


### PR DESCRIPTION
This pull request introduces a new GitHub workflow to automate image compression for pull requests. The workflow targets specific image file types and utilizes a reusable workflow for the compression process.

Automation for image compression:

* [`.github/workflows/pr-compress-images.yml`](diffhunk://#diff-008c2eebaab3f3a4d09e469632f838a5cb27836bc6a9db7e76aa3b5088e262a6R1-R21): Added a new workflow named "PR Compress Images" that triggers on pull requests targeting image files (`.jpg`, `.jpeg`, `.png`, `.webp`) and includes permissions for pull requests and repository contents. It uses a reusable workflow for image compression.